### PR TITLE
use js and module.exports instead of json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   ],
   "dependencies": {
     "o-comment-utilities": "^2.2.0",
-    "o-comment-api": "^2.3.0-beta.1"
+    "o-comment-api": "bjfletcher/o-comment-api#^2.3.1"
   },
   "ignore": [
     "node_modules",

--- a/config.js
+++ b/config.js
@@ -1,3 +1,3 @@
-{
+module.exports = {
 	"template": "{count} Comment{plural}"
 }

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 const config = require('./src/javascripts/config.js');
 const oCommentApi = require('o-comment-api');
-const defaultConfig = require('./config.json');
+const defaultConfig = require('./config.js');
 const oCommentUtilities = require('o-comment-utilities');
 const Widget = require('./src/javascripts/Widget.js');
 


### PR DESCRIPTION
Please change `o-comment-api` dependency from mine to your when released.
